### PR TITLE
Correct memcache service name in Acquia recipe

### DIFF
--- a/recipes/acquia/acquia-settings.inc
+++ b/recipes/acquia/acquia-settings.inc
@@ -11,6 +11,6 @@ $databases['default']['default'] = [
 ];
 
 $settings['hash_salt'] = md5(getenv('LANDO_HOST_IP'));
-$settings['memcache']['servers'] = ['memcached:11211' => 'default'];
+$settings['memcache']['servers'] = ['cache:11211' => 'default'];
 $settings['memcache']['bins'] = ['default' => 'default'];
 $settings['memcache']['key_prefix'] = '';


### PR DESCRIPTION
The recipe defines a memcache service named `cache` but the recipe's provided settings file attempts to use the service name `memcached` and (silently) fails to connect to the memcache backend. This PR sets the correct name in the settings file provided by the recipe.