### PR TITLE
Set ACLI_DB env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
+## v0.8.0 - [May 16, 2023](https://github.com/lando/acquia/releases/tag/v0.8.0)
+
+* Set ACLI_DB env vars [#56](https://github.com/lando/acquia/pull/56)
+
 ## v0.7.0 - [December 12, 2022](https://github.com/lando/acquia/releases/tag/v0.7.0)
-  * Added bundle-dependencies to release process.
-  * Fixed bug in plugin dogfooding test.
+* Added bundle-dependencies to release process.
+* Fixed bug in plugin dogfooding test.
 
 ## v0.6.0 - [September 7, 2022](https://github.com/lando/acquia/releases/tag/v0.6.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.8.0 - [May 16, 2023](https://github.com/lando/acquia/releases/tag/v0.8.0)
+## v0.8.0 - [May 17, 2023](https://github.com/lando/acquia/releases/tag/v0.8.0)
 
 * Added ACLI_DB env vars [#56](https://github.com/lando/acquia/pull/56)
 * Updated to PHP 8.1 in the engagedemo app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.8.0 - [May 16, 2023](https://github.com/lando/acquia/releases/tag/v0.8.0)
 
-* Set ACLI_DB env vars [#56](https://github.com/lando/acquia/pull/56)
+* Added ACLI_DB env vars [#56](https://github.com/lando/acquia/pull/56)
+* Updated to PHP 8.1 in the engagedemo app.
 
 ## v0.7.0 - [December 12, 2022](https://github.com/lando/acquia/releases/tag/v0.7.0)
 * Added bundle-dependencies to release process.

--- a/examples/drupal/README.md
+++ b/examples/drupal/README.md
@@ -64,7 +64,7 @@ lando ssh -c "/usr/local/bin/composer --version" | grep Composer | grep "2.0.11"
 
 # Should use php version 7.4 by default
 cd drupal9
-lando php -v | grep "PHP 7.4"
+lando php -v | grep "PHP 8.1"
 
 # Should be able to bootstrap drupal9
 cd drupal9

--- a/examples/drupal/README.md
+++ b/examples/drupal/README.md
@@ -19,7 +19,7 @@ lando poweroff
 # Should initialize the lando acquia test drupal9 site
 rm -rf drupal9 && mkdir -p drupal9 && cd drupal9
 lando init --source acquia --acquia-key "$ACQUIA_API_KEY" --acquia-secret "$ACQUIA_API_SECRET" --acquia-app "53fd24cf-803f-4024-afac-c457cfc5c273" --acquia-key-name "$RUN_ID"
-echo -e "\nplugins:\n  \"@lando/acquia/\": ./../../" >> .lando.yml
+echo -e "\nplugins:\n  \"@lando/acquia/\": ./../../../" >> .lando.yml
 git stash
 
 # Should start up our drupal9 site successfully

--- a/examples/drupal/README.md
+++ b/examples/drupal/README.md
@@ -75,6 +75,11 @@ cd drupal9
 lando ssh -c "env" | grep AH_SITE_ENVIRONMENT | grep LANDO
 lando ssh -c "env" | grep AH_SITE_GROUP | grep engagedemo
 lando ssh -c "env" | grep AH_SITE_UUID | grep 53fd24cf-803f-4024-afac-c457cfc5c273
+lando ssh -c "env" | grep ACLI_DB_HOST | grep database
+lando ssh -c "env" | grep ACLI_DB_USER | grep acquia 
+lando ssh -c "env" | grep ACLI_DB_PASSWORD | grep acquia
+lando ssh -c "env" | grep ACLI_DB_NAME | grep acquia
+
 
 # Should be running from the docroot directory
 cd drupal9

--- a/recipes/acquia/builder.js
+++ b/recipes/acquia/builder.js
@@ -84,6 +84,10 @@ module.exports = {
         AH_SITE_UUID: appUuid,
         AH_SITE_GROUP: group,
         AH_SITE_ENVIRONMENT: 'LANDO',
+        ACLI_DB_HOST: 'database',
+        ACLI_DB_USER: 'acquia',
+        ACLI_DB_PASSWORD: 'acquia',
+        ACLI_DB_NAME: 'acquia',
       };
 
       // Mount the acquia settings.php file for auto service "discovery"


### PR DESCRIPTION
Acquia CLI has a magical awareness of certain environments, including Lando and Cloud IDE. I think that's an anti-pattern.

Environments providing Acquia CLI should instead inform ACLI of things like db settings via these env vars.

Corresponding PR to remove this magical thinking from ACLI: https://github.com/acquia/cli/pull/1468