### PR TITLE
Fix Acquia auth by switching to URL-encoded OAuth request format

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,23 +20,23 @@ module.exports = (app, lando) => {
         if (answers.key && answers.secret) {
           const api = new API();
           return api.auth(answers.key, answers.secret, true, true)
-              .then(() => api.getAccount())
-              .then(account => {
-                // This is good auth, lets update our cache
-                const cache = {key: answers.key, label: account.mail, secret: answers.secret};
-                // Reset this apps metacache
-                lando.cache.set(app.metaCache, _.merge({}, app.meta, cache), {persist: true});
-                // Reset the acquia key cache
-                const keys = utils.sortKeys(app.acquiaKeys, app.hostKeys, [cache]);
-                lando.cache.set(app.acquiaKeyCache, keys, {persist: true});
-                // Blow away tooling cache so we can reset our pull commands
-                lando.cache.remove(`${app.name}.tooling.cache`);
-              })
-              // Throw some sort of error
-              // NOTE: this provides some error handling when we are completely non-interactive
-              .catch(err => {
-                throw (_.has(err, 'response.data')) ? new Error(err.response.data) : err;
-              });
+            .then(() => api.getAccount())
+            .then(account => {
+              // This is good auth, lets update our cache
+              const cache = {key: answers.key, label: account.mail, secret: answers.secret};
+              // Reset this apps metacache
+              lando.cache.set(app.metaCache, _.merge({}, app.meta, cache), {persist: true});
+              // Reset the acquia key cache
+              const keys = utils.sortKeys(app.acquiaKeys, app.hostKeys, [cache]);
+              lando.cache.set(app.acquiaKeyCache, keys, {persist: true});
+              // Blow away tooling cache so we can reset our pull commands
+              lando.cache.remove(`${app.name}.tooling.cache`);
+            })
+          // Throw some sort of error
+          // NOTE: this provides some error handling when we are completely non-interactive
+            .catch(err => {
+              throw (_.has(err, 'response.data')) ? new Error(err.response.data) : err;
+            });
         }
       });
     });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,11 @@ export default [
     rules: {
       'arrow-parens': ['error', 'as-needed'],
 
+      'indent': ['error', 2, {
+        MemberExpression: 1,
+        SwitchCase: 1,
+      }],
+
       'max-len': ['error', {
         code: 140,
         ignoreComments: true,

--- a/inits/acquia.js
+++ b/inits/acquia.js
@@ -71,12 +71,12 @@ const getAutoCompleteSites = (answers, lando, input = null) => {
   // how the user is going to provide us with the auth creds
   const {key, secret} = getAuthPair(answers);
   return api.auth(key, secret, true, true)
-      .then(() => api.getApplications())
-      .then(apps => _.map(apps, app => (_.merge({}, {name: app.name, value: app.uuid}, app))))
-      .then(apps => {
-        acquiaApps = apps;
-        return lando.Promise.resolve(acquiaApps);
-      });
+    .then(() => api.getApplications())
+    .then(apps => _.map(apps, app => (_.merge({}, {name: app.name, value: app.uuid}, app))))
+    .then(apps => {
+      acquiaApps = apps;
+      return lando.Promise.resolve(acquiaApps);
+    });
 };
 
 /*
@@ -103,10 +103,10 @@ module.exports = {
         type: 'input',
         message: 'Enter an Acquia API token key, visit https://cloud.acquia.com/a/profile/tokens to create one',
         when: answers => showKeyEntry(
-            answers.recipe,
-            answers['acquia-key'],
-            lando.config.home,
-            lando.cache.get(acquiaKeyCache),
+          answers.recipe,
+          answers['acquia-key'],
+          lando.config.home,
+          lando.cache.get(acquiaKeyCache),
         ),
         validate: (input, answers) => {
           // If we end up here we likely need to ask for the secret as well
@@ -190,12 +190,12 @@ module.exports = {
         name: 'get-user-account',
         func: options => {
           return api.auth(options['acquia-key'], options['acquia-secret'], true, true)
-              .then(() => api.getAccount())
-              .then(account => {
-                options['acquia-account'] = account;
-                options['acquia-keyname'] = `${account.mail}.acquia.lando.id_rsa`;
-                options['acquia-keycomment'] = `${account.mail}@lando`;
-              });
+            .then(() => api.getAccount())
+            .then(account => {
+              options['acquia-account'] = account;
+              options['acquia-keyname'] = `${account.mail}.acquia.lando.id_rsa`;
+              options['acquia-keycomment'] = `${account.mail}@lando`;
+            });
         },
       },
       {
@@ -208,29 +208,29 @@ module.exports = {
           const pubKey = path.join(lando.config.userConfRoot, 'keys', `${options['acquia-keyname']}.pub`);
           const keyName = options['acquia-key-name'];
           return api.auth(options['acquia-key'], options['acquia-secret'], true, true)
-              .then(() => api.postKey(pubKey, keyName));
+            .then(() => api.postKey(pubKey, keyName));
         },
       },
       {
         name: 'get-git-url',
         func: options => {
           return api.auth(options['acquia-key'], options['acquia-secret'], true, true)
-              .then(() => api.getEnvironments(options['acquia-app']))
-              .then(envs => {
-                // Match our euuid with acquias
-                const env = utils.getBestEnv(envs);
-                // Get GIT URL
-                options['acquia-git-url'] = env.git;
-                // And some other things
-                const parts = env.vcs.split('/');
-                if (parts[0] === 'tags') {
-                  options['acquia-git-branch'] = parts[1];
-                } else {
-                  options['acquia-git-branch'] = env.vcs;
-                }
-                options['acquia-php-version'] = env.php;
-                options['acquia-site-group'] = env.group;
-              });
+            .then(() => api.getEnvironments(options['acquia-app']))
+            .then(envs => {
+              // Match our euuid with acquias
+              const env = utils.getBestEnv(envs);
+              // Get GIT URL
+              options['acquia-git-url'] = env.git;
+              // And some other things
+              const parts = env.vcs.split('/');
+              if (parts[0] === 'tags') {
+                options['acquia-git-branch'] = parts[1];
+              } else {
+                options['acquia-git-branch'] = env.vcs;
+              }
+              options['acquia-php-version'] = env.php;
+              options['acquia-site-group'] = env.group;
+            });
         },
       },
       {
@@ -249,43 +249,43 @@ module.exports = {
   build: (options, lando) => {
     // Get the info we need to build the relevant config
     return api.auth(options['acquia-key'], options['acquia-secret'], true, true)
-        .then(() => Promise.all([
-          api.getAccount(),
-          api.getEnvironments(options['acquia-app']),
-        ]))
-        .then(data => {
-          const account = data[0];
-          const env = utils.getBestEnv(data[1]);
-          // Write the acli-cli.yml file
-          utils.writeAcliUuid(options['acquia-app']);
-          // Reset the name to something human readable
-          options.name = env.group;
-          // Merge in other lando config
-          const landofileConfig = {
-            config: {
-              acli_version: 'latest',
-              ah_application_uuid: options['acquia-app'],
-              ah_site_group: env.group,
-              php: env.php,
-            },
-          };
+      .then(() => Promise.all([
+        api.getAccount(),
+        api.getEnvironments(options['acquia-app']),
+      ]))
+      .then(data => {
+        const account = data[0];
+        const env = utils.getBestEnv(data[1]);
+        // Write the acli-cli.yml file
+        utils.writeAcliUuid(options['acquia-app']);
+        // Reset the name to something human readable
+        options.name = env.group;
+        // Merge in other lando config
+        const landofileConfig = {
+          config: {
+            acli_version: 'latest',
+            ah_application_uuid: options['acquia-app'],
+            ah_site_group: env.group,
+            php: env.php,
+          },
+        };
 
-          // This is good auth, lets update our cache
-          const cache = {
-            key: options['acquia-key'],
-            label: account.mail,
-            secret: options['acquia-secret'],
-          };
+        // This is good auth, lets update our cache
+        const cache = {
+          key: options['acquia-key'],
+          label: account.mail,
+          secret: options['acquia-secret'],
+        };
 
-          // Update lando's store of acquia creds
-          const keys = lando.cache.get(acquiaKeyCache) || [];
-          lando.cache.set(acquiaKeyCache, utils.sortKeys(keys, [cache]), {persist: true});
-          // Update app metdata
-          const metaData = lando.cache.get(`${options.name}.meta.cache`);
-          lando.cache.set(`${options.name}.meta.cache`, _.merge({}, metaData, cache), {persist: true});
+        // Update lando's store of acquia creds
+        const keys = lando.cache.get(acquiaKeyCache) || [];
+        lando.cache.set(acquiaKeyCache, utils.sortKeys(keys, [cache]), {persist: true});
+        // Update app metdata
+        const metaData = lando.cache.get(`${options.name}.meta.cache`);
+        lando.cache.set(`${options.name}.meta.cache`, _.merge({}, metaData, cache), {persist: true});
 
-          // Finish up
-          return landofileConfig;
-        });
+        // Finish up
+        return landofileConfig;
+      });
   },
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -159,7 +159,7 @@ module.exports = class AcquiaApi {
    */
   postKey(key, label = 'Lando') {
     // Key Post data
-    const postData = {label, public_key: _.trim(fs.readFileSync(key, 'utf8')) };
+    const postData = {label, public_key: _.trim(fs.readFileSync(key, 'utf8'))};
     // Start by the users keys
     return this.api.get('/account/ssh-keys')
       // Only grab the lando ones
@@ -168,7 +168,7 @@ module.exports = class AcquiaApi {
         .value())
       // If we dont have a match lets post the new one
       .then(landoKeys => {
-        if (_.isEmpty(_.find(landoKeys, { public_key: postData.public_key }))) {
+        if (_.isEmpty(_.find(landoKeys, {public_key: postData.public_key}))) {
           postData.label = `${label}${landoKeys.length + 1}`;
           return this.api.post('/account/ssh-keys', postData)
             .catch(err => {

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,12 +3,12 @@
 const _ = require('lodash');
 const axios = require('axios');
 const fs = require('fs');
+const qs = require('qs');
 
 module.exports = class AcquiaApi {
   constructor(lando) {
     /** @type {object} Lando instance, used for promises and other Lando utilities. */
     this.lando = lando;
-    axios.defaults.baseURL = 'https://cloud.acquia.com/api/';
     /** @type {string} The base URL for Acquia account authentication. */
     this.authURL = 'https://accounts.acquia.com/api/auth/oauth/token';
     /** @type {object|null} Stores the Acquia API authentication token. */
@@ -17,6 +17,7 @@ module.exports = class AcquiaApi {
     this.account = null;
     /** @type {Array<object>|null} Stores the list of Acquia applications. */
     this.applications = null;
+    this.api = null;
   }
 
   /**
@@ -38,28 +39,42 @@ module.exports = class AcquiaApi {
     }
     // Clear account to assure the account on this object
     // matches the token if auth is run more than once.
-    return axios.post(this.authURL, {
+    const data = qs.stringify({
       client_id: clientId,
       client_secret: clientSecret,
       grant_type: 'client_credentials',
       scope: '',
+    });
+
+    return axios.post(this.authURL, data, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
     })
-        .then(res => {
+      .then(res => {
         // Set token and auth headers
-          this.token = res.data;
-          axios.defaults.headers.common = {'Authorization': `Bearer ${this.token.access_token}`};
-        })
-        .catch(err => {
-          throw err.response.data.error_description;
-        }).then(() => {
-          if (tokenOnly) {
-            return this.token;
-          }
-          return this.getAccount().then(data => {
-            this.account = data;
-            return this.account;
-          });
+        this.token = res.data;
+
+        // Create a new axios instance with the token for futere requests
+        this.api = axios.create({
+          baseURL: 'https://cloud.acquia.com/api/',
+          headers: {
+            Authorization: `Bearer ${this.token.access_token}`,
+          },
         });
+      })
+      .catch(err => {
+        throw err.response.data.error_description;
+      })
+      .then(() => {
+        if (tokenOnly) {
+          return this.token;
+        }
+        return this.getAccount().then(data => {
+          this.account = data;
+          return this.account;
+        });
+      });
   }
 
   /**
@@ -70,7 +85,7 @@ module.exports = class AcquiaApi {
    * Each object contains id, uuid, subuuid, and name.
    */
   getApplications() {
-    return axios.get('https://cloud.acquia.com/api/applications').then(res => {
+    return this.api.get('/applications').then(res => {
       const total = res.data.total;
       this.applications = total === 0 ? [] : res.data._embedded.items.map(item => ({
         id: item.id,
@@ -80,9 +95,9 @@ module.exports = class AcquiaApi {
       }));
       return this.applications;
     })
-        .catch(error => {
-          console.log(error);
-        });
+      .catch(error => {
+        console.log(error);
+      });
   }
 
   /**
@@ -93,7 +108,7 @@ module.exports = class AcquiaApi {
    * Each object contains name, displayName, git URL, group, PHP version, value (ID), and vcs path.
    */
   getEnvironments(appId) {
-    return axios.get(`https://cloud.acquia.com/api/applications/${appId}/environments`).then(res => {
+    return this.api.get(`/applications/${appId}/environments`).then(res => {
       const total = res.data.total;
       this.environments = [];
       const envs = total === 0 ? [] : res.data._embedded.items;
@@ -111,9 +126,9 @@ module.exports = class AcquiaApi {
       });
       return this.environments;
     })
-        .catch(error => {
-          console.log(error);
-        });
+      .catch(error => {
+        console.log(error);
+      });
   }
 
   /**
@@ -123,7 +138,7 @@ module.exports = class AcquiaApi {
    * @return {Promise<object>} A promise that resolves to the account object.
    */
   getAccount() {
-    return axios.get('https://cloud.acquia.com/api/account').then(res => {
+    return this.api.get('/account').then(res => {
       this.account = res.data;
       return this.account;
     }).catch(error => {
@@ -144,22 +159,22 @@ module.exports = class AcquiaApi {
    */
   postKey(key, label = 'Lando') {
     // Key Post data
-    const postData = {label, public_key: _.trim(fs.readFileSync(key, 'utf8'))};
+    const postData = {label, public_key: _.trim(fs.readFileSync(key, 'utf8')) };
     // Start by the users keys
-    return axios.get('https://cloud.acquia.com/api/account/ssh-keys')
-    // Only grab the lando ones
-        .then(response => _(_.get(response, 'data._embedded.items', []))
-            .filter(key => _.startsWith(key.label, label))
-            .value())
-    // If we dont have a match lets post the new one
-        .then(landoKeys => {
-          if (_.isEmpty(_.find(landoKeys, {public_key: postData.public_key}))) {
-            postData.label = `${label}${landoKeys.length + 1}`;
-            return axios.post(`https://cloud.acquia.com/api/account/ssh-keys`, postData)
-                .catch(err => {
-                  throw new Error(_.get(err, 'response.data.message', 'Something went wrong posting your key!'));
-                });
-          }
-        });
+    return this.api.get('/account/ssh-keys')
+      // Only grab the lando ones
+      .then(response => _(_.get(response, 'data._embedded.items', []))
+        .filter(key => _.startsWith(key.label, label))
+        .value())
+      // If we dont have a match lets post the new one
+      .then(landoKeys => {
+        if (_.isEmpty(_.find(landoKeys, { public_key: postData.public_key }))) {
+          postData.label = `${label}${landoKeys.length + 1}`;
+          return this.api.post('/account/ssh-keys', postData)
+            .catch(err => {
+              throw new Error(_.get(err, 'response.data.message', 'Something went wrong posting your key!'));
+            });
+        }
+      });
   }
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -36,16 +36,16 @@ const getEnvs = (key, secret, uuid) => {
 
   // Otherwise fetch them
   return api.auth(key, secret, true, true)
-      .then(() => api.getEnvironments(uuid))
-      .then(envs => _(envs)
-          .map(env => _.merge({}, env, {name: env.displayName, value: env.name}))
-          .value(),
-      )
-      .then(envs => {
-        acquiaEnvs = envs;
-        acquiaEnvs.push({'name': 'none', 'value': 'none'});
-        return envs;
-      });
+    .then(() => api.getEnvironments(uuid))
+    .then(envs => _(envs)
+      .map(env => _.merge({}, env, {name: env.displayName, value: env.name}))
+      .value(),
+    )
+    .then(envs => {
+      acquiaEnvs = envs;
+      acquiaEnvs.push({'name': 'none', 'value': 'none'});
+      return envs;
+    });
 };
 
 /**

--- a/lib/push.js
+++ b/lib/push.js
@@ -36,17 +36,17 @@ const getEnvs = (key, secret, uuid) => {
 
   // Otherwise fetch them
   return api.auth(key, secret, true, true)
-      .then(() => api.getEnvironments(uuid))
-      .then(envs => _(envs)
-          .filter(env => (env.name !== 'prod'))
-          .map(env => _.merge({}, env, {name: env.displayName, value: env.name}))
-          .value(),
-      )
-      .then(envs => {
-        acquiaEnvs = envs;
-        acquiaEnvs.push({'name': 'none', 'value': 'none'});
-        return envs;
-      });
+    .then(() => api.getEnvironments(uuid))
+    .then(envs => _(envs)
+      .filter(env => (env.name !== 'prod'))
+      .map(env => _.merge({}, env, {name: env.displayName, value: env.name}))
+      .value(),
+    )
+    .then(envs => {
+      acquiaEnvs = envs;
+      acquiaEnvs.push({'name': 'none', 'value': 'none'});
+      return envs;
+    });
 };
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,9 +55,9 @@ exports.writeAcliUuid = (uuid, file = '.acquia-cli.yml') => {
 exports.getAcquiaKeyChoices = lando => {
   const keys = exports.getAcquiaKeys(lando);
   return _(keys)
-      .map(key => ({name: key.label, value: key.uuid, secret: key.secret}))
-      .thru(keys => keys.concat([{name: 'add a key', value: 'more'}]))
-      .value();
+    .map(key => ({name: key.label, value: key.uuid, secret: key.secret}))
+    .thru(keys => keys.concat([{name: 'add a key', value: 'more'}]))
+    .value();
 };
 
 /**
@@ -134,9 +134,9 @@ exports.getHostKeys = home => {
  * @return {Array<object>} An array of Inquirer choice objects.
  */
 exports.getKeys = (keys = []) => _(keys)
-    .map(key => ({name: key.label, value: `${key.key}:${key.secret}`}))
-    .thru(keys => keys.concat([{name: 'add or refresh a key', value: 'more'}]))
-    .value();
+  .map(key => ({name: key.label, value: `${key.key}:${key.secret}`}))
+  .thru(keys => keys.concat([{name: 'add or refresh a key', value: 'more'}]))
+  .value();
 
 /**
  * Merges multiple arrays of key objects, ensuring uniqueness by `uuid`,
@@ -146,9 +146,9 @@ exports.getKeys = (keys = []) => _(keys)
  * @return {Array<object>} A single array of unique, sorted key objects.
  */
 exports.sortKeys = (...sources) => _(_.flattenDeep(sources))
-    .uniqBy('uuid')
-    .orderBy('label')
-    .value();
+  .uniqBy('uuid')
+  .orderBy('label')
+  .value();
 
 /**
  * Constructs a shell command string to download and install a specific version of Drush phar.
@@ -158,10 +158,10 @@ exports.sortKeys = (...sources) => _(_.flattenDeep(sources))
  * @return {string} A shell command string for installing Drush.
  */
 exports.getDrush = (version, status) => exports.getPhar(
-    getDrushUrl(version),
-    '/tmp/drush.phar',
-    '/usr/local/bin/drush',
-    status,
+  getDrushUrl(version),
+  '/tmp/drush.phar',
+  '/usr/local/bin/drush',
+  status,
 );
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.6.7",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "qs": "^6.14.0",
         "semver": "^7.6.0"
       },
       "devDependencies": {
@@ -3509,6 +3510,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4148,6 +4178,20 @@
         "dottojs": "bin/dot-packer"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.72",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.72.tgz",
@@ -4190,6 +4234,36 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-semver": {
@@ -4904,7 +4978,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5000,6 +5073,30 @@
         "node": "*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5008,6 +5105,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -5074,6 +5184,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -5174,6 +5296,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasha": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
@@ -5205,7 +5339,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6005,6 +6138,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/md5-hex": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-4.0.0.tgz",
@@ -6697,6 +6839,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -7114,6 +7268,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -7646,6 +7815,78 @@
         "@shikijs/types": "2.1.0",
         "@shikijs/vscode-textmate": "^10.0.1",
         "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "axios": "^1.6.7",
     "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
+    "qs": "^6.14.0",
     "semver": "^7.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🔧 Fix Acquia auth by switching to URL-encoded OAuth request format

### Context

When running `lando init` and selecting **Acquia** as the source, I entered my API credentials and received the error:
```bash 
Cannot set properties of undefined (setting 'verbose')
```

To debug the issue, I installed the Acquia plugin locally into my `.lando/plugins/` directory and added a `console.log` in the `api.js` file. Upon sending the OAuth request, I received:

```json
{
  "errorCode": "E0000021",
  "errorSummary": "Bad request. Accept and/or Content-Type headers likely do not match supported values."
}
```

### Root cause
Checking [Acquia's official API documentation](https://docs.acquia.com/cloud-platform/develop/api/auth/), their OAuth endpoint requires application/x-www-form-urlencoded, but the plugin was sending JSON (application/json).

### What this PR does
Changes the ```auth()``` request in ```api.js``` to use ```qs.stringify(...)``` for the body. 
Adds the `qs` library as a dependency to enable this encoding.
Sets ```Content-Type: application/x-www-form-urlencoded``` as required by Acquia.

### ✅ Bare minimum self-checks
- [x] I've updated this PR with the latest code from `main`
- [x] I've done a cursory QA pass of my code locally
- [ ] I've ensured all automated status check and tests pass
- [ ] I've connected this PR to an issue

### 💥 Pieces of flare
- [ ] I've written a unit or functional test for my code
- [ ] I've updated relevant documentation if my code changes it
- [ ] I've updated this repo's README if my code changes it
- [ ] I've updated this repo's CHANGELOG with my change unless it's a trivial change

### 🙏 Finally
- [ ] I've requested a review with relevant people

If you're unsure or want more guidance, feel free to join `#contributors` on [Lando Slack](https://www.launchpass.com/devwithlando)!

