### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
+
 * Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output
 * Fixed MySQL 8.4 startup failure by removing hardcoded `mysql_native_password` authentication [lando/mysql#69](https://github.com/lando/mysql/issues/69)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lando/mailhog": "^1.2.3",
         "@lando/memcached": "^1.4.2",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.11.1",
+        "@lando/php": "^1.12.0",
         "@lando/postgres": "^1.5.0",
         "axios": "^1.11.0",
         "js-yaml": "^4.1.0",
@@ -1690,9 +1690,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.1.tgz",
-      "integrity": "sha512-3l6oEj6iZxL4vj59YbOinfu4ktUXYfHe7UlP1W5wePTaQH9K+RBCg8eCsPBmliQzc9ltX6JqvDYrAx2KN5K8Dw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",
@@ -1709,7 +1709,7 @@
       }
     },
     "node_modules/@lando/php/node_modules/@lando/nginx": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "bundleDependencies": [
         "lodash"
       ],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@lando/mailhog": "^1.2.3",
     "@lando/memcached": "^1.4.2",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.11.1",
+    "@lando/php": "^1.12.0",
     "@lando/postgres": "^1.5.0",
     "axios": "^1.11.0",
     "js-yaml": "^4.1.0",


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this updates the underlying PHP service image/plugin, which can change runtime Apache module defaults and debugging behavior for all users.
> 
> **Overview**
> Updates `@lando/php` from `^1.11.1` to `^1.12.0`, pulling in upstream changes (notably default `mod_headers`/`mod_expires` enablement and an xdebug log ownership fix).
> 
> Refreshes `package-lock.json` for the new `@lando/php` release (including its bundled `@lando/nginx` version change) and records the upgrade in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f6f771a8db3294b88f6eacbaba04e5a21e4a3fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->